### PR TITLE
Promises: Fix Bug where a reject promised followed by than and a catch will never caught.

### DIFF
--- a/examples/promise/__tests__/promise.test.js
+++ b/examples/promise/__tests__/promise.test.js
@@ -101,6 +101,36 @@ describe('Promise', () => {
         });
     });
 
+    it('should allow catch after a then with sync resolved promise', done => {
+      const errorMessage = 'Promise has been rejected';
+      const thenFn = jest.fn();
+
+      return new NPromise((resolve, reject) => {
+        return reject(new Error(errorMessage));
+      })
+        .then(thenFn)
+        .catch(error => {
+          expect(error.message).toBe(errorMessage);
+          expect(thenFn).toHaveBeenCalledTimes(0);
+          done();
+        });
+    });
+
+    it('should allow catch after a then with async resolved promise', done => {
+      const errorMessage = 'Promise has been rejected';
+      const thenFn = jest.fn();
+
+      return new NPromise((resolve, reject) => {
+        setTimeout(() => reject(new Error(errorMessage)), 10);
+      })
+        .then(thenFn)
+        .catch(error => {
+          expect(error.message).toBe(errorMessage);
+          expect(thenFn).toHaveBeenCalledTimes(0);
+          done();
+        });
+    });
+
     it('should allow catch an error thrown by a previous catch method', done => {
       const errorMessage = 'Promise has been rejected';
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "jest",
+    "test:promise": "jest /examples/promise",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "prettier:check": "prettier -c 'examples/**/*.js'",


### PR DESCRIPTION
Hey @waldemarnt, this changes aims to fix a bug on the following promise compositions.

```
new NPromise((resolve, reject) => {
        return reject(new Error(errorMessage));
      })
        .then(x => console.log(x))
        .catch(error => {
          console.log(error.message); // <-- never called
        });

new NPromise((resolve, reject) => {
        setTimeout(() => reject(new Error(errorMessage)), 10);
      })
        .then(x => console.log(x))
        .catch(error => {
          console.log(error.message); // <-- never called
        });
```

As far as I understood we need to treat in the `then` method a case where the previous promised was rejected. Without this implementation, any previous rejected promise would fall in the `else` pushing the onFulFilled to the onfulFillChain array. Because the first promise was rejected, the resolve method will never be triggered, and it state will never change.
With this proposed change, the behavior becomes similar to the native node promise implementation. After a reject promise, all subsequents `thens` will be rejected until a `catch` is found on the chain.

I would like to know your thoughts about that.

Also, I thought about add onReject in the `then`, and transform `catch` into just a wrapper over t`hen(null, onReject)`, but because it is a different topic, I opted to not include in this PR.
